### PR TITLE
ENH: SIMPL Backwards Compatibility Test Redesign

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,8 @@ set(${PLUGIN_NAME}UnitTest_SRCS
     MergeColoniesTest.cpp
     ComputeLocalAverageCAxisMisalignmentsTest.cpp
     ComputeMicroTextureRegionsTest.cpp
+    ComputeSaltykovSizesTest.cpp
+    GroupMicroTextureRegionsTest.cpp
 )
 set(DISABLED_TESTS
 

--- a/test/ComputeLocalAverageCAxisMisalignmentsTest.cpp
+++ b/test/ComputeLocalAverageCAxisMisalignmentsTest.cpp
@@ -22,14 +22,19 @@
 
 #include <catch2/catch.hpp>
 
+#include "simplnx/Core/Application.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "SimplnxReview/Filters/ComputeLocalAverageCAxisMisalignmentsFilter.hpp"
 #include "SimplnxReview/SimplnxReview_test_dirs.hpp"
+
+#include <fstream>
 
 using namespace nx::core;
 
@@ -65,3 +70,50 @@ TEST_CASE("SimplnxReview::ComputeLocalAverageCAxisMisalignmentsFilter: Valid Fil
 //{
 //
 // }
+
+TEST_CASE("SimplnxReview::ComputeLocalAverageCAxisMisalignmentsFilter: SIMPL Backwards Compatibility", "[SimplnxReview][ComputeLocalAverageCAxisMisalignmentsFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "ComputeLocalAverageCAxisMisalignmentsFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "ComputeLocalAverageCAxisMisalignmentsFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<ComputeLocalAverageCAxisMisalignmentsFilter>::uuid);
+
+      CHECK(pipelineFilter->getComments().empty());
+
+      const Arguments args = pipelineFilter->getArguments();
+      CHECK(args.value<DataPath>(ComputeLocalAverageCAxisMisalignmentsFilter::k_AvgCAxisMisalignmentsPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(ComputeLocalAverageCAxisMisalignmentsFilter::k_CAxisMisalignmentListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<bool>(ComputeLocalAverageCAxisMisalignmentsFilter::k_CalcBiasedAvg_Key) == true);
+      CHECK(args.value<bool>(ComputeLocalAverageCAxisMisalignmentsFilter::k_CalcUnbiasedAvg_Key) == true);
+      CHECK(args.value<DataPath>(ComputeLocalAverageCAxisMisalignmentsFilter::k_FeatureParentIdsPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(ComputeLocalAverageCAxisMisalignmentsFilter::k_LocalCAxisMisalignmentsName_Key) == "TestName");
+      CHECK(args.value<DataPath>(ComputeLocalAverageCAxisMisalignmentsFilter::k_NeighborListPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(ComputeLocalAverageCAxisMisalignmentsFilter::k_NumFeaturesPerParentName_Key) == "TestName");
+      CHECK(args.value<DataPath>(ComputeLocalAverageCAxisMisalignmentsFilter::k_NewCellFeatureAttributeMatrixPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::string>(ComputeLocalAverageCAxisMisalignmentsFilter::k_UnbiasedLocalCAxisMisalignmentsName_Key) == "TestName");
+    }
+  }
+}

--- a/test/ComputeMicroTextureRegionsTest.cpp
+++ b/test/ComputeMicroTextureRegionsTest.cpp
@@ -22,13 +22,18 @@
 
 #include <catch2/catch.hpp>
 
+#include "simplnx/Core/Application.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/DataGroupSelectionParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "SimplnxReview/Filters/ComputeMicroTextureRegionsFilter.hpp"
 #include "SimplnxReview/SimplnxReview_test_dirs.hpp"
+
+#include <fstream>
 
 using namespace nx::core;
 
@@ -58,3 +63,44 @@ TEST_CASE("SimplnxReview::ComputeMicroTextureRegionsFilter: Valid Filter Executi
 //{
 //
 // }
+
+TEST_CASE("SimplnxReview::ComputeMicroTextureRegionsFilter: SIMPL Backwards Compatibility", "[SimplnxReview][ComputeMicroTextureRegionsFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "ComputeMicroTextureRegionsFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "ComputeMicroTextureRegionsFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<ComputeMicroTextureRegionsFilter>::uuid);
+
+      CHECK(pipelineFilter->getComments().empty());
+
+      const Arguments args = pipelineFilter->getArguments();
+      CHECK(args.value<DataPath>(ComputeMicroTextureRegionsFilter::k_CellFeatureAttributeMatrixPath_Key) == DataPath({"DataContainer"}));
+      CHECK(args.value<std::string>(ComputeMicroTextureRegionsFilter::k_MicroTextureRegionFractionOccupiedArrayName_Key) == "TestName");
+      CHECK(args.value<std::string>(ComputeMicroTextureRegionsFilter::k_MicroTextureRegionNumCellsArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(ComputeMicroTextureRegionsFilter::k_FeatureIdsArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+    }
+  }
+}

--- a/test/ComputeSaltykovSizesTest.cpp
+++ b/test/ComputeSaltykovSizesTest.cpp
@@ -1,0 +1,52 @@
+#include <catch2/catch.hpp>
+
+#include "simplnx/Core/Application.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
+
+#include "SimplnxReview/Filters/ComputeSaltykovSizesFilter.hpp"
+#include "SimplnxReview/SimplnxReview_test_dirs.hpp"
+
+#include <fstream>
+
+using namespace nx::core;
+
+TEST_CASE("SimplnxReview::ComputeSaltykovSizesFilter: SIMPL Backwards Compatibility", "[SimplnxReview][ComputeSaltykovSizesFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "ComputeSaltykovSizesFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "ComputeSaltykovSizesFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<ComputeSaltykovSizesFilter>::uuid);
+
+      CHECK(pipelineFilter->getComments().empty());
+
+      const Arguments args = pipelineFilter->getArguments();
+      CHECK(args.value<DataPath>(ComputeSaltykovSizesFilter::k_EquivalentDiametersArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(ComputeSaltykovSizesFilter::k_SaltykovEquivalentDiametersName_Key) == "TestArray");
+    }
+  }
+}

--- a/test/GroupMicroTextureRegionsTest.cpp
+++ b/test/GroupMicroTextureRegionsTest.cpp
@@ -22,13 +22,19 @@
 
 #include <catch2/catch.hpp>
 
+#include "simplnx/Core/Application.hpp"
 #include "simplnx/Parameters/ArraySelectionParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/NumberParameter.hpp"
 #include "simplnx/Parameters/StringParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
+#include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "SimplnxReview/Filters/GroupMicroTextureRegionsFilter.hpp"
 #include "SimplnxReview/SimplnxReview_test_dirs.hpp"
+
+#include <fstream>
 
 using namespace nx::core;
 
@@ -68,3 +74,54 @@ TEST_CASE("SimplnxReview::GroupMicroTextureRegionsFilter: Valid Filter Execution
 //{
 //
 // }
+
+TEST_CASE("SimplnxReview::GroupMicroTextureRegionsFilter: SIMPL Backwards Compatibility", "[SimplnxReview][GroupMicroTextureRegionsFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "GroupMicroTextureRegionsFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "GroupMicroTextureRegionsFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<GroupMicroTextureRegionsFilter>::uuid);
+
+      CHECK(pipelineFilter->getComments().empty());
+
+      const Arguments args = pipelineFilter->getArguments();
+      CHECK(args.value<std::string>(GroupMicroTextureRegionsFilter::k_ActiveArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_AvgQuatsArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<float32>(GroupMicroTextureRegionsFilter::k_CAxisTolerance_Key) == 2.5f);
+      CHECK(args.value<std::string>(GroupMicroTextureRegionsFilter::k_CellParentIdsArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_ContiguousNeighborListArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_CrystalStructuresArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_FeatureIdsArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(GroupMicroTextureRegionsFilter::k_FeatureParentIdsArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_FeaturePhasesArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_NewCellFeatureAttributeMatrixName_Key) == DataPath({"TestName"}));
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_NonContiguousNeighborListArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<bool>(GroupMicroTextureRegionsFilter::k_UseNonContiguousNeighbors_Key) == true);
+      CHECK(args.value<bool>(GroupMicroTextureRegionsFilter::k_UseRunningAverage_Key) == true);
+      CHECK(args.value<DataPath>(GroupMicroTextureRegionsFilter::k_VolumesArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+    }
+  }
+}

--- a/test/MergeColoniesTest.cpp
+++ b/test/MergeColoniesTest.cpp
@@ -1,12 +1,17 @@
 #include <catch2/catch.hpp>
 
+#include "simplnx/Core/Application.hpp"
 #include "simplnx/Parameters/ArrayCreationParameter.hpp"
 #include "simplnx/Parameters/BoolParameter.hpp"
 #include "simplnx/Parameters/DataObjectNameParameter.hpp"
+#include "simplnx/Pipeline/Pipeline.hpp"
+#include "simplnx/Pipeline/PipelineFilter.hpp"
 #include "simplnx/UnitTest/UnitTestCommon.hpp"
 
 #include "SimplnxReview/Filters/MergeColoniesFilter.hpp"
 #include "SimplnxReview/SimplnxReview_test_dirs.hpp"
+
+#include <fstream>
 
 using namespace nx::core;
 
@@ -32,4 +37,56 @@ TEST_CASE("SimplnxReview::MergeColoniesFilter: Valid Filter Execution", "[Simpln
   args.insertOrAssign(MergeColoniesFilter::k_NewCellFeatureAttributeMatrixName_Key, std::make_any<DataPath>(DataPath{}));
   args.insertOrAssign(MergeColoniesFilter::k_FeatureParentIdsArrayName_Key, std::make_any<DataObjectNameParameter::ValueType>(""));
   args.insertOrAssign(MergeColoniesFilter::k_ActiveArrayName_Key, std::make_any<DataObjectNameParameter::ValueType>(""));
+}
+
+TEST_CASE("SimplnxReview::MergeColoniesFilter: SIMPL Backwards Compatibility", "[SimplnxReview][MergeColoniesFilter][BackwardsCompatibility]")
+{
+  auto app = Application::GetOrCreateInstance();
+  UnitTest::LoadPlugins();
+  auto filterList = app->getFilterList();
+
+  const fs::path conversionDir = fs::path(nx::core::unit_test::k_SourceDir.view()) / "test" / "simpl_conversion";
+
+  const std::vector<std::pair<std::string, fs::path>> fixtures = {
+      {"SIMPL 6.5 (UUID)", conversionDir / "6_5" / "MergeColoniesFilter.json"},
+      {"SIMPL 6.4 (Filter_Name)", conversionDir / "6_4" / "MergeColoniesFilter.json"},
+  };
+
+  for(const auto& [label, fixturePath] : fixtures)
+  {
+    DYNAMIC_SECTION(label)
+    {
+      auto pipelineResult = Pipeline::FromSIMPLFile(fixturePath, filterList);
+      REQUIRE(pipelineResult.valid());
+
+      auto& pipeline = pipelineResult.value();
+      REQUIRE(pipeline.size() == 1);
+
+      auto* pipelineFilter = dynamic_cast<PipelineFilter*>(pipeline.at(0));
+      REQUIRE(pipelineFilter != nullptr);
+
+      const IFilter* filter = pipelineFilter->getFilter();
+      REQUIRE(filter != nullptr);
+      REQUIRE(filter->uuid() == FilterTraits<MergeColoniesFilter>::uuid);
+
+      CHECK(pipelineFilter->getComments().empty());
+
+      const Arguments args = pipelineFilter->getArguments();
+      CHECK(args.value<std::string>(MergeColoniesFilter::k_ActiveArrayName_Key) == "TestName");
+      CHECK(args.value<float32>(MergeColoniesFilter::k_AngleTolerance_Key) == 2.5f);
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_AvgQuatsArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<float32>(MergeColoniesFilter::k_AxisTolerance_Key) == 2.5f);
+      CHECK(args.value<std::string>(MergeColoniesFilter::k_CellParentIdsArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_CellPhasesArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_ContiguousNeighborListArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_CrystalStructuresArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_FeatureIdsArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<std::string>(MergeColoniesFilter::k_FeatureParentIdsArrayName_Key) == "TestName");
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_FeaturePhasesArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      // AMPathBuilderFilterParameterConverter - verified by successful pipeline loading
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_NewCellFeatureAttributeMatrixName_Key) == DataPath({"DataContainer", "TestName"}));
+      CHECK(args.value<DataPath>(MergeColoniesFilter::k_NonContiguousNeighborListArrayPath_Key) == DataPath({"DataContainer", "CellData", "TestArray"}));
+      CHECK(args.value<bool>(MergeColoniesFilter::k_UseNonContiguousNeighbors_Key) == true);
+    }
+  }
 }

--- a/test/simpl_conversion/6_4/ComputeLocalAverageCAxisMisalignmentsFilter.json
+++ b/test/simpl_conversion/6_4/ComputeLocalAverageCAxisMisalignmentsFilter.json
@@ -1,0 +1,40 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Local Average C-Axis Misalignments 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find Local Average C-Axis Misalignments",
+    "Filter_Name": "FindLocalAverageCAxisMisalignments",
+    "AvgCAxisMisalignmentsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CAxisMisalignmentListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CalcBiasedAvg": 1,
+    "CalcUnbiasedAvg": 1,
+    "FeatureParentIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "LocalCAxisMisalignmentsArrayName": "TestName",
+    "NeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NumFeaturesPerParentArrayName": "TestName",
+    "NewCellFeatureAttributeMatrixName": {
+      "Data Container Name": "DataContainer"
+    },
+    "UnbiasedLocalCAxisMisalignmentsArrayName": "TestName"
+  }
+}

--- a/test/simpl_conversion/6_4/ComputeMicroTextureRegionsFilter.json
+++ b/test/simpl_conversion/6_4/ComputeMicroTextureRegionsFilter.json
@@ -1,0 +1,22 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Micro Texture Regions 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find MicroTexture Regions",
+    "Filter_Name": "FindMicroTextureRegions",
+    "CellFeatureAttributeMatrixName": {
+      "Data Container Name": "DataContainer"
+    },
+    "MicroTextureRegionFractionOccupiedArrayName": "TestName",
+    "MicroTextureRegionNumCellsArrayName": "TestName",
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_4/ComputeSaltykovSizesFilter.json
+++ b/test/simpl_conversion/6_4/ComputeSaltykovSizesFilter.json
@@ -1,0 +1,22 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Saltykov Sizes 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find Saltykov Sizes",
+    "Filter_Name": "FindSaltykovSizes",
+    "EquivalentDiametersArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "SaltykovEquivalentDiametersArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_4/GroupMicroTextureRegionsFilter.json
+++ b/test/simpl_conversion/6_4/GroupMicroTextureRegionsFilter.json
@@ -1,0 +1,54 @@
+{
+  "PipelineBuilder": {
+    "Name": "Group Micro Texture Regions 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Group MicroTexture Regions",
+    "Filter_Name": "GroupMicroTextureRegions",
+    "ActiveArrayName": "TestName",
+    "AvgQuatsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CAxisTolerance": 2.5,
+    "CellParentIdsArrayName": "TestName",
+    "ContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CrystalStructuresArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureParentIdsArrayName": "TestName",
+    "FeaturePhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NewCellFeatureAttributeMatrixName": "TestName",
+    "NonContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "UseNonContiguousNeighbors": 1,
+    "UseRunningAverage": 1,
+    "VolumesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_4/MergeColoniesFilter.json
+++ b/test/simpl_conversion/6_4/MergeColoniesFilter.json
@@ -1,0 +1,54 @@
+{
+  "PipelineBuilder": {
+    "Name": "Merge Colonies 6.4 Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Merge Colonies",
+    "Filter_Name": "MergeColonies",
+    "ActiveArrayName": "TestName",
+    "AngleTolerance": 2.5,
+    "AvgQuatsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "AxisTolerance": 2.5,
+    "CellParentIdsArrayName": "TestName",
+    "CellPhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "ContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CrystalStructuresArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureParentIdsArrayName": "TestName",
+    "FeaturePhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NewCellFeatureAttributeMatrixName": "TestName",
+    "NonContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "UseNonContiguousNeighbors": 1
+  }
+}

--- a/test/simpl_conversion/6_5/ComputeLocalAverageCAxisMisalignmentsFilter.json
+++ b/test/simpl_conversion/6_5/ComputeLocalAverageCAxisMisalignmentsFilter.json
@@ -1,0 +1,41 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Local Average C-Axis Misalignments Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find Local Average C-Axis Misalignments",
+    "Filter_Name": "FindLocalAverageCAxisMisalignments",
+    "Filter_Uuid": "{49b2dd47-bb29-50d4-a051-5bad9b6b9f80}",
+    "AvgCAxisMisalignmentsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CAxisMisalignmentListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CalcBiasedAvg": 1,
+    "CalcUnbiasedAvg": 1,
+    "FeatureParentIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "LocalCAxisMisalignmentsArrayName": "TestName",
+    "NeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NumFeaturesPerParentArrayName": "TestName",
+    "NewCellFeatureAttributeMatrixName": {
+      "Data Container Name": "DataContainer"
+    },
+    "UnbiasedLocalCAxisMisalignmentsArrayName": "TestName"
+  }
+}

--- a/test/simpl_conversion/6_5/ComputeMicroTextureRegionsFilter.json
+++ b/test/simpl_conversion/6_5/ComputeMicroTextureRegionsFilter.json
@@ -1,0 +1,23 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Micro Texture Regions Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find MicroTexture Regions",
+    "Filter_Name": "FindMicroTextureRegions",
+    "Filter_Uuid": "{90f8e3b1-2460-5862-95a1-a9e06f5ee75e}",
+    "CellFeatureAttributeMatrixName": {
+      "Data Container Name": "DataContainer"
+    },
+    "MicroTextureRegionFractionOccupiedArrayName": "TestName",
+    "MicroTextureRegionNumCellsArrayName": "TestName",
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_5/ComputeSaltykovSizesFilter.json
+++ b/test/simpl_conversion/6_5/ComputeSaltykovSizesFilter.json
@@ -1,0 +1,23 @@
+{
+  "PipelineBuilder": {
+    "Name": "Compute Saltykov Sizes Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Find Saltykov Sizes",
+    "Filter_Name": "FindSaltykovSizes",
+    "Filter_Uuid": "{cc76cffe-81ad-5ece-be2a-ce127c5fa6d7}",
+    "EquivalentDiametersArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "SaltykovEquivalentDiametersArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_5/GroupMicroTextureRegionsFilter.json
+++ b/test/simpl_conversion/6_5/GroupMicroTextureRegionsFilter.json
@@ -1,0 +1,55 @@
+{
+  "PipelineBuilder": {
+    "Name": "Group Micro Texture Regions Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Group MicroTexture Regions",
+    "Filter_Name": "GroupMicroTextureRegions",
+    "Filter_Uuid": "{5e18a9e2-e342-56ac-a54e-3bd0ca8b9c53}",
+    "ActiveArrayName": "TestName",
+    "AvgQuatsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CAxisTolerance": 2.5,
+    "CellParentIdsArrayName": "TestName",
+    "ContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CrystalStructuresArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureParentIdsArrayName": "TestName",
+    "FeaturePhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NewCellFeatureAttributeMatrixName": "TestName",
+    "NonContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "UseNonContiguousNeighbors": 1,
+    "UseRunningAverage": 1,
+    "VolumesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    }
+  }
+}

--- a/test/simpl_conversion/6_5/MergeColoniesFilter.json
+++ b/test/simpl_conversion/6_5/MergeColoniesFilter.json
@@ -1,0 +1,55 @@
+{
+  "PipelineBuilder": {
+    "Name": "Merge Colonies Backwards Compatibility Test",
+    "Number_Filters": 1,
+    "Version": 6
+  },
+  "0": {
+    "Filter_Enabled": true,
+    "Filter_Human_Label": "Merge Colonies",
+    "Filter_Name": "MergeColonies",
+    "Filter_Uuid": "{2c4a6d83-6a1b-56d8-9f65-9453b28845b9}",
+    "ActiveArrayName": "TestName",
+    "AngleTolerance": 2.5,
+    "AvgQuatsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "AxisTolerance": 2.5,
+    "CellParentIdsArrayName": "TestName",
+    "CellPhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "ContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "CrystalStructuresArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureIdsArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "FeatureParentIdsArrayName": "TestName",
+    "FeaturePhasesArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "NewCellFeatureAttributeMatrixName": "TestName",
+    "NonContiguousNeighborListArrayPath": {
+      "Data Container Name": "DataContainer",
+      "Attribute Matrix Name": "CellData",
+      "Data Array Name": "TestArray"
+    },
+    "UseNonContiguousNeighbors": 1
+  }
+}


### PR DESCRIPTION
Replace the centralized test with per-filter backwards compatibility tests embedded in each filter's existing test file. Each test:

Loads a small SIMPL pipeline JSON fixture (stored in git, not in the test data archive) through Pipeline::FromSIMPLFile — the same code path the application uses
Verifies the correct filter was resolved via UUID mapping
Checks that conversion completed without errors
Asserts the converted parameter values match expected values
Tests both SIMPL 6.5 (with UUID) and 6.4 (Filter_Name only) pipeline formats via DYNAMIC_SECTION

Depends on https://github.com/BlueQuartzSoftware/simplnx/pull/1605
